### PR TITLE
[CONTRIB] cast to str in query template values

### DIFF
--- a/great_expectations/expectations/metrics/query_metrics/query_template_values.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_template_values.py
@@ -28,7 +28,7 @@ class QueryTemplateValues(QueryMetricProvider):
     @classmethod
     def get_query(cls, query, template_dict, selectable):
         template_dict_reformatted = {
-            k: v.format(active_batch=selectable) for k, v in template_dict.items()
+            k: str(v).format(active_batch=selectable) for k, v in template_dict.items()
         }
         query_reformatted = query.format(
             **template_dict_reformatted, active_batch=selectable


### PR DESCRIPTION
Hi, 
The query template values metric (that we contributed) is sometime getting INT values in the values of the dict, which fails the .format() function - becuae INT has no format function.
I casted the value to str for protection. 
I checked it with our expectations and it solve the issue. 
can you please check?

Thanks!